### PR TITLE
Parquet date path

### DIFF
--- a/src/main/scala/dpla/batch_process_dpla_index/entries/AllProcessesEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/AllProcessesEntry.scala
@@ -8,9 +8,10 @@ import org.apache.spark.sql.SparkSession
   * Main entry point for executing all processes.
   *
   * Args
-  *   args(0) = parquetOut    The full local or S3 output path, ending in ".parquet"
-  *                           e.g. s3a://dpla-provider-export/2019/01/all.parquet
-  *
+  *   args(0) = parquetOut    Local or S3 path to the top-level directory destination.
+  * *                         Month and year will be added to the auto-generated file paths.
+  * *                         e.g. s3a://dpla-provider-export/
+  * *
   *   args(1) = jsonlOut      Local or S3 path to the top-level directory destination.
   *                           Month and year will be added to the auto-generated file paths.
   *                           e.g. s3a://dpla-provider-export/

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/ParquetDumpEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/ParquetDumpEntry.scala
@@ -8,9 +8,10 @@ import org.apache.spark.sql.SparkSession
   * Main entry point for generating a parquet dump of the DPLA ElasticSearch index.
   *
   * Args
-  *   args(0) = outpath   The full local or S3 output path, ending in ".parquet"
-  *                       e.g. s3a://dpla-provider-export/2019/01/all.parquet
-  *
+  *   args(0) = outpath   Local or S3 path to the top-level directory destination.
+  * *                     Month and year will be added to the auto-generated file paths.
+  * *                     e.g. s3a://dpla-provider-export/
+  * *
   *   args(1) = query     Optional parameters for an ElasticSearch query,
   *                       e.g. ?q=hamster
   *

--- a/src/main/scala/dpla/batch_process_dpla_index/helpers/ManifestWriter.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/helpers/ManifestWriter.scala
@@ -6,15 +6,12 @@ import scala.collection.immutable.SortedMap
 
 trait ManifestWriter {
 
-  def buildManifest(opts: Map[String, String], dateTime: ZonedDateTime): String = {
-    val date: String = dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
-
-    // Add date/time to given `opts'
-    val data: Map[String, String] = opts + ("Start date/time of file generation" -> date)
+  def buildManifest(opts: Map[String, String]): String = {
 
     // Sort by key for legibility
-    val sorted = SortedMap[String, String]() ++ data
+    val sorted = SortedMap[String, String]() ++
+        opts + ("Start date/time of file generation" -> PathHelper.timestamp)
 
-    sorted.map{ case(k, v) => s"$k: $v" }.mkString("\n")
+    sorted.map { case (k, v) => s"$k: $v" }.mkString("\n")
   }
 }

--- a/src/main/scala/dpla/batch_process_dpla_index/helpers/PathHelper.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/helpers/PathHelper.scala
@@ -1,0 +1,11 @@
+package dpla.batch_process_dpla_index.helpers
+
+import java.time.{LocalDateTime, ZoneOffset, ZonedDateTime}
+import java.time.format.DateTimeFormatter
+
+object PathHelper {
+  val dateTime: ZonedDateTime = LocalDateTime.now().atZone(ZoneOffset.UTC)
+  val year: String = dateTime.format(DateTimeFormatter.ofPattern("yyyy"))
+  val month: String = dateTime.format(DateTimeFormatter.ofPattern("MM"))
+  val outDir: String =  "/" + year + "/" + month
+}

--- a/src/main/scala/dpla/batch_process_dpla_index/helpers/PathHelper.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/helpers/PathHelper.scala
@@ -7,5 +7,6 @@ object PathHelper {
   val dateTime: ZonedDateTime = LocalDateTime.now().atZone(ZoneOffset.UTC)
   val year: String = dateTime.format(DateTimeFormatter.ofPattern("yyyy"))
   val month: String = dateTime.format(DateTimeFormatter.ofPattern("MM"))
+  val timestamp: String = dateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
   val outDir: String =  "/" + year + "/" + month
 }

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/JsonlDump.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/JsonlDump.scala
@@ -69,7 +69,7 @@ object JsonlDump extends S3FileHelper with LocalFileWriter with ManifestWriter {
         "Record count" -> x.count.toString,
         "Max records per file (approximate)" -> maxRows.toString,
         "Data source" -> x.input)
-      writeManifest(manifestOpts, outDir, dateTime)
+      writeManifest(manifestOpts, outDir)
     })
 
     // Export all providers dump
@@ -89,7 +89,7 @@ object JsonlDump extends S3FileHelper with LocalFileWriter with ManifestWriter {
       x.provider + " record count" -> x.count.toString
     )).reduce(_++_)
 
-    writeManifest(allOpts ++ providerOpts, outDir, dateTime)
+    writeManifest(allOpts ++ providerOpts, outDir)
 
     outDir
   }
@@ -99,10 +99,10 @@ object JsonlDump extends S3FileHelper with LocalFileWriter with ManifestWriter {
     data.repartition(numPartitions).saveAsTextFile(outDir, classOf[GzipCodec])
   }
 
-  def writeManifest(opts: Map[String, String], outDir: String, dateTime: ZonedDateTime): Unit = {
+  def writeManifest(opts: Map[String, String], outDir: String): Unit = {
     val s3write: Boolean = outDir.startsWith("s3")
 
-    val manifest: String = buildManifest(opts, dateTime)
+    val manifest: String = buildManifest(opts)
 
     if (s3write) writeS3(outDir, "_MANIFEST", manifest)
     else writeLocal(outDir, "_MANIFEST", manifest)

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/JsonlDump.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/JsonlDump.scala
@@ -3,7 +3,7 @@ package dpla.batch_process_dpla_index.processes
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDateTime, ZoneOffset, ZonedDateTime}
 
-import dpla.batch_process_dpla_index.helpers.{LocalFileWriter, ManifestWriter, S3FileHelper}
+import dpla.batch_process_dpla_index.helpers.{LocalFileWriter, ManifestWriter, PathHelper, S3FileHelper}
 import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -21,10 +21,7 @@ object JsonlDump extends S3FileHelper with LocalFileWriter with ManifestWriter {
 
   def execute(spark: SparkSession, outpath: String): String = {
 
-    val dateTime: ZonedDateTime = LocalDateTime.now().atZone(ZoneOffset.UTC)
-    val year: String = dateTime.format(DateTimeFormatter.ofPattern("yyyy"))
-    val month: String = dateTime.format(DateTimeFormatter.ofPattern("MM"))
-    val outDirBase: String = outpath.stripSuffix("/") + "/" + year + "/" + month
+    val outDirBase: String = outpath.stripSuffix("/") + PathHelper.outDir
 
     val allFiles = getS3Keys(s3client.listObjects(inputBucket)).toList
 

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/MqReports.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/MqReports.scala
@@ -3,7 +3,7 @@ package dpla.batch_process_dpla_index.processes
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDateTime, ZoneOffset, ZonedDateTime}
 
-import dpla.batch_process_dpla_index.helpers.{LocalFileWriter, ManifestWriter, S3FileHelper}
+import dpla.batch_process_dpla_index.helpers.{LocalFileWriter, ManifestWriter, PathHelper, S3FileHelper}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.functions._
 
@@ -12,11 +12,7 @@ object MqReports extends LocalFileWriter with S3FileHelper with ManifestWriter {
   def execute(spark: SparkSession, inpath: String, outpath: String): String = {
 
     val s3write: Boolean = outpath.startsWith("s3")
-
-    val dateTime: ZonedDateTime = LocalDateTime.now().atZone(ZoneOffset.UTC)
-    val year: String = dateTime.format(DateTimeFormatter.ofPattern("yyyy"))
-    val month: String = dateTime.format(DateTimeFormatter.ofPattern("MM"))
-    val outDir: String = outpath.stripSuffix("/") + "/" + year + "/" + month
+    val outDir: String = outpath.stripSuffix("/") + PathHelper.outDir
 
     val docs: DataFrame = spark.read.parquet(inpath)
 

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/MqReports.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/MqReports.scala
@@ -112,7 +112,7 @@ object MqReports extends LocalFileWriter with S3FileHelper with ManifestWriter {
       "Provider count" -> providerScores.count.toString,
       "Contributor count" -> contributorScores.count.toString
     )
-    val manifest: String = buildManifest(opts, dateTime)
+    val manifest: String = buildManifest(opts)
 
     if (s3write) writeS3(outDir, "_MANIFEST", manifest)
     else writeLocal(outDir, "_MANIFEST", manifest)

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/ParquetDump.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/ParquetDump.scala
@@ -12,7 +12,7 @@ object ParquetDump extends LocalFileWriter with S3FileHelper with ManifestWriter
 
     val s3write: Boolean = outpath.startsWith("s3")
 
-    val outDirBase: String = outpath.stripSuffix("/") + PathHelper.outDir + "all.parquet/"
+    val outDirBase: String = outpath.stripSuffix("/") + PathHelper.outDir + "/all.parquet/"
 
     val dateTime: ZonedDateTime = LocalDateTime.now().atZone(ZoneOffset.UTC)
 

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/ParquetDump.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/ParquetDump.scala
@@ -29,8 +29,8 @@ object ParquetDump extends LocalFileWriter with S3FileHelper with ManifestWriter
 
     val manifest: String = buildManifest(opts)
 
-    if (s3write) writeS3(outpath, "_MANIFEST", manifest)
-    else writeLocal(outpath, "_MANIFEST", manifest)
+    if (s3write) writeS3(outDirBase, "_MANIFEST", manifest)
+    else writeLocal(outDirBase, "_MANIFEST", manifest)
 
     // return output path
     outDirBase

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/ParquetDump.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/ParquetDump.scala
@@ -27,7 +27,7 @@ object ParquetDump extends LocalFileWriter with S3FileHelper with ManifestWriter
       "Record count" -> count.toString,
       "Data source" -> "DPLA ElasticSearch Index")
 
-    val manifest: String = buildManifest(opts, dateTime)
+    val manifest: String = buildManifest(opts)
 
     if (s3write) writeS3(outpath, "_MANIFEST", manifest)
     else writeLocal(outpath, "_MANIFEST", manifest)

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/ParquetDump.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/ParquetDump.scala
@@ -2,7 +2,7 @@ package dpla.batch_process_dpla_index.processes
 
 import java.time.{LocalDateTime, ZoneOffset, ZonedDateTime}
 
-import dpla.batch_process_dpla_index.helpers.{LocalFileWriter, ManifestWriter, S3FileHelper}
+import dpla.batch_process_dpla_index.helpers.{LocalFileWriter, ManifestWriter, PathHelper, S3FileHelper}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.storage.StorageLevel
 
@@ -12,6 +12,8 @@ object ParquetDump extends LocalFileWriter with S3FileHelper with ManifestWriter
 
     val s3write: Boolean = outpath.startsWith("s3")
 
+    val outDirBase: String = outpath.stripSuffix("/") + PathHelper.outDir + "all.parquet/"
+
     val dateTime: ZonedDateTime = LocalDateTime.now().atZone(ZoneOffset.UTC)
 
     val dump: DataFrame = spark.read.format("dpla.datasource").option("query", query)
@@ -19,7 +21,7 @@ object ParquetDump extends LocalFileWriter with S3FileHelper with ManifestWriter
 
     val count: Long = dump.count
 
-    dump.write.parquet(outpath)
+    dump.write.parquet(outDirBase)
 
     val opts: Map[String, String] = Map(
       "Record count" -> count.toString,
@@ -31,6 +33,6 @@ object ParquetDump extends LocalFileWriter with S3FileHelper with ManifestWriter
     else writeLocal(outpath, "_MANIFEST", manifest)
 
     // return output path
-    outpath
+    outDirBase
   }
 }

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/Sitemap.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/Sitemap.scala
@@ -61,7 +61,7 @@ object Sitemap extends S3FileHelper with LocalFileWriter with ManifestWriter {
       "Total URL count" -> id_count.toString,
       "Max URLs per subfile" -> maxRows.toString)
 
-    val manifest: String = buildManifest(opts, dateTime)
+    val manifest: String = buildManifest(opts)
 
     if (s3write) writeS3(outpath, "_MANIFEST", manifest)
     else writeLocal(outpath, "_MANIFEST", manifest)


### PR DESCRIPTION
I centralized the path creation logic and made the Parquet dump figure out the year/month path for symmetry with the other processes. Also, the manifest timestamp logic is centralized as well.