### PR TITLE
remove right from metadata completeness

### DIFF
--- a/src/main/scala/dpla/batch_process_dpla_index/processes/MqReports.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/MqReports.scala
@@ -64,10 +64,6 @@ object MqReports extends LocalFileWriter with S3FileHelper with ManifestWriter {
                                           then 1 else 0 end
                                           as openRights,
                                         case
-                                          when size(sourceResource.rights) == 0
-                                          then 0 else 1 end
-                                          as rights,
-                                        case
                                           when size(object) == 0
                                           then 0 else 1 end
                                           as preview,
@@ -98,7 +94,6 @@ object MqReports extends LocalFileWriter with S3FileHelper with ManifestWriter {
         mean("spatial").alias("spatial"),
         mean("subject").alias("subject"),
         mean("date").alias("date"),
-        mean("rights").alias("rights"),
         mean("standardizedRights").alias("standardizedRights"),
         mean("preview").alias("preview"),
         mean("iiifManifest").alias("iiifManifest"),
@@ -122,7 +117,6 @@ object MqReports extends LocalFileWriter with S3FileHelper with ManifestWriter {
         mean("spatial").alias("spatial"),
         mean("subject").alias("subject"),
         mean("date").alias("date"),
-        mean("rights").alias("rights"),
         mean("standardizedRights").alias("standardizedRights"),
         mean("preview").alias("preview"),
         mean("iiifManifest").alias("iiifManifest"),


### PR DESCRIPTION
This removes `sourceResource.rights` (i.e. non-standardized rights) from the metadata completeness report, which is used in the hub analytics dashboard.  We decided to remove `sourceResource.rights` b/c it's required now, and so no longer helpful to include in the hub dashboard.  Standardized rights statement remains.