### PR TITLE
Fix necro index

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,6 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % "2.3.2" % "provided",
   "com.amazonaws" % "aws-java-sdk" % "1.7.4",
   "org.apache.hadoop" % "hadoop-aws" % "2.7.7",
-  "org.elasticsearch" %% "elasticsearch-spark-20" % "7.3.0",
+  "org.elasticsearch" % "elasticsearch-spark-20_2.11" % "7.3.2",
   "com.squareup.okhttp3" % "okhttp" % "3.8.0"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "2.3.2" % "provided",
   "org.apache.spark" %% "spark-sql" % "2.3.2" % "provided",
   "com.amazonaws" % "aws-java-sdk" % "1.7.4",
-  "org.elasticsearch" % "elasticsearch-spark-20_2.11" % "7.3.2",
-  "org.apache.hadoop" % "hadoop-aws" % "2.7.6",
+  "org.apache.hadoop" % "hadoop-aws" % "2.7.7",
+  "org.elasticsearch" %% "elasticsearch-spark-20" % "7.3.0",
   "com.squareup.okhttp3" % "okhttp" % "3.8.0"
 )

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/AllProcessesEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/AllProcessesEntry.scala
@@ -75,8 +75,8 @@ object AllProcessesEntry {
       val shards = 3
       val replicas = 1
 
-//      val necroPath = NecroData.execute(spark, parquetPath, tombstoneOut, None)
-      val necroPath = "s3a://dpla-necropolis/test/2020/07/tombstones.parquet"
+      val parquetPath = "s3a://dpla-provider-export/2020/07/all.parquet"
+      val necroPath = NecroData.execute(spark, parquetPath, tombstoneOut, None)
       NecroIndex.execute(spark, necroPath, esClusterHost, esPort, alias, shards, replicas)
     }
     

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/AllProcessesEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/AllProcessesEntry.scala
@@ -62,10 +62,10 @@ object AllProcessesEntry {
     val conf: SparkConf = new SparkConf().setAppName("Batch process DPLA index: All processes")
     val spark: SparkSession = SparkSession.builder().config(conf).getOrCreate()
 
-//    val parquetPath = ParquetDump.execute(spark, parquetOut, query)
-//    JsonlDump.execute(spark, jsonlOut)
-//    MqReports.execute(spark, parquetPath, mqOut)
-//    Sitemap.execute(spark, parquetPath, sitemapOut, sitemapUrlPrefix)
+    val parquetPath = ParquetDump.execute(spark, parquetOut, query)
+    JsonlDump.execute(spark, jsonlOut)
+    MqReports.execute(spark, parquetPath, mqOut)
+    Sitemap.execute(spark, parquetPath, sitemapOut, sitemapUrlPrefix)
 
     if (doNecro){
       // TODO Double check that these are good default values - should any be parameterized?
@@ -75,7 +75,6 @@ object AllProcessesEntry {
       val shards = 3
       val replicas = 1
 
-      val parquetPath = "s3a://dpla-provider-export/2020/07/all.parquet"
       val necroPath = NecroData.execute(spark, parquetPath, tombstoneOut, None)
       NecroIndex.execute(spark, necroPath, esClusterHost, esPort, alias, shards, replicas)
     }

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/AllProcessesEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/AllProcessesEntry.scala
@@ -62,10 +62,10 @@ object AllProcessesEntry {
     val conf: SparkConf = new SparkConf().setAppName("Batch process DPLA index: All processes")
     val spark: SparkSession = SparkSession.builder().config(conf).getOrCreate()
 
-    val parquetPath = ParquetDump.execute(spark, parquetOut, query)
-    JsonlDump.execute(spark, jsonlOut)
-    MqReports.execute(spark, parquetPath, mqOut)
-    Sitemap.execute(spark, parquetPath, sitemapOut, sitemapUrlPrefix)
+//    val parquetPath = ParquetDump.execute(spark, parquetOut, query)
+//    JsonlDump.execute(spark, jsonlOut)
+//    MqReports.execute(spark, parquetPath, mqOut)
+//    Sitemap.execute(spark, parquetPath, sitemapOut, sitemapUrlPrefix)
 
     if (doNecro){
       // TODO Double check that these are good default values - should any be parameterized?
@@ -75,7 +75,8 @@ object AllProcessesEntry {
       val shards = 3
       val replicas = 1
 
-      val necroPath = NecroData.execute(spark, parquetPath, tombstoneOut, None)
+//      val necroPath = NecroData.execute(spark, parquetPath, tombstoneOut, None)
+      val necroPath = "s3a://dpla-necropolis/test/2020/07/tombstones.parquet"
       NecroIndex.execute(spark, necroPath, esClusterHost, esPort, alias, shards, replicas)
     }
     

--- a/src/main/scala/dpla/batch_process_dpla_index/helpers/Index.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/helpers/Index.scala
@@ -169,7 +169,7 @@ class Index(
     try
       if (!response.isSuccessful) {
         throw new RuntimeException(
-          s"FAILED request for ${request.url.toString} (${response.code}, " +
+          s"FAILED request for ${request.url.toString} ${request.body.toString} (${response.code}, " +
             s"${response.message})"
         )
       }

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/NecroData.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/NecroData.scala
@@ -40,19 +40,17 @@ object NecroData extends S3FileHelper with LocalFileWriter with ManifestWriter {
       .join(newData, Seq("id"), "leftanti")
       .withColumn("lastActive", lit(lastDate))
 
-    // If there is more than one "tombstone" (i.e. row) with the same ID,
-    // get only the tombstone with the most recent "lastActive" date.
-    // If there is more than one tombstone with the same lastActive date,
-    // choose one at random.
-    // TODO: is there a better solution than choosing at random for the above scenario?
-
-
     //  Get the old tombstones.
     val oldTombs = spark.read.parquet(oldTombsPath).distinct
 
     // Join old and new tombstones.
     val tombstonesWithDups = oldTombs.union(newTombs)
 
+    // If there is more than one "tombstone" (i.e. row) with the same ID,
+    // get only the tombstone with the most recent "lastActive" date.
+    // If there is more than one tombstone with the same lastActive date,
+    // choose one at random.
+    // TODO: is there a better solution than choosing at random for the above scenario?
     val tombstones = tombstonesWithDups
       .groupBy("id")
       .agg(last("lastActive").as("lastActive"))

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/NecroData.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/NecroData.scala
@@ -44,7 +44,10 @@ object NecroData extends S3FileHelper with LocalFileWriter with ManifestWriter {
     val oldTombs = spark.read.parquet(oldTombsPath).distinct
 
     // Join old and new tombstones.
+    // Filter out any records with missing ids.
     val tombstonesWithDups = oldTombs.union(newTombs)
+      .filter("id is not null")
+      .filter("id != ''")
 
     // If there is more than one "tombstone" (i.e. row) with the same ID,
     // get only the tombstone with the most recent "lastActive" date.


### PR DESCRIPTION
Several fixes here to things uncovered in the process of testing the necropolis index build on the complete dataset in the cluster.

1. The build file is brought into alignment with the Jenkins deployment
2. An error message is made more informative
3. Records with missing ids or ids that are empty strings are removed (this is likely from pre-ingestion3 data)
4. When there are multiple "tombstones" for a given id, the most recent one is selected (this presumably happens when items are removed and added back into the collection multiple times)

With these changes, the necropolis index successfully builds on the cluster.