### PR TITLE
do not delete old necro index

### DIFF
--- a/src/main/scala/dpla/batch_process_dpla_index/helpers/Index.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/helpers/Index.scala
@@ -101,11 +101,9 @@ class Index(
   }
 
   // Set alias for this index.
-  // Delete any old indices with this alias.
   def deploy(alias: String): Unit = {
     val oldIndices: Set[String] = getAliasedIndices(alias)
     setExclusiveAlias(alias, oldIndices)
-    oldIndices.foreach(name => new Index(host, port, name, shards, replicas, httpClient).deleteIndex())
   }
 
   private def getAliasedIndices(alias: String): Set[String] = {


### PR DESCRIPTION
Before, the old necropolis indices were automatically deleted, which could lead to problems if the builds failed or bugged out.  This keeps old indices (but does assign the `necropolis` alias to the newly built index).