### PR TITLE
Allows emr resumability by deleting existing s3 keys

### DIFF
--- a/monthly_batch_emr.sh
+++ b/monthly_batch_emr.sh
@@ -11,9 +11,9 @@ sitemap_root="http://sitemaps.dp.la/"
 necropolis_out="s3a://dpla-necropolis/"
 do_necro="true"
 
-# sbt assembly
-# echo "Copying to s3://dpla-monthly-batch/"
-# aws s3 cp ./target/scala-2.11/batch-process-dpla-index-assembly-0.1.jar s3://dpla-monthly-batch/
+sbt assembly
+echo "Copying to s3://dpla-monthly-batch/"
+aws s3 cp ./target/scala-2.11/batch-process-dpla-index-assembly-0.1.jar s3://dpla-monthly-batch/
 
 
 # spin up EMR cluster and run job 
@@ -41,21 +41,15 @@ aws emr create-cluster \
       "--deploy-mode",
       "cluster",
       "--class",
-      "dpla.batch_process_dpla_index.entries.AllProcessesEntry",
+      "dpla.batch_process_dpla_index.entries.ParquetDumpEntry",
       "s3://dpla-monthly-batch/batch-process-dpla-index-assembly-0.1.jar",
-      "'"$parquet_out"'",
-      "'"$jsonl_out"'",
-      "'"$metadata_quality_out"'",
-      "'"$sitemap_out"'",
-      "'"$sitemap_root"'",
-      "'"$necropolis_out"'",
-      "'"$do_necro"'"
+      "'"$parquet_out"'"
     ],
     "Type": "CUSTOM_JAR",
     "ActionOnFailure": "TERMINATE_CLUSTER",
     "Jar": "command-runner.jar",
     "Properties": "",
-    "Name": "monthlybatch"
+    "Name": "parquet"
   }
 ]' \
 --name 'monthlybatch' \

--- a/monthly_batch_emr.sh
+++ b/monthly_batch_emr.sh
@@ -50,6 +50,57 @@ aws emr create-cluster \
     "Jar": "command-runner.jar",
     "Properties": "",
     "Name": "parquet"
+  },
+  {
+    "Args": [
+      "spark-submit",
+      "--deploy-mode",
+      "cluster",
+      "--class",
+      "dpla.batch_process_dpla_index.entries.JsonlDumpEntry",
+      "s3://dpla-monthly-batch/batch-process-dpla-index-assembly-0.1.jar",
+      "'"$jsonl_out"'"
+    ],
+    "Type": "CUSTOM_JAR",
+    "ActionOnFailure": "TERMINATE_CLUSTER",
+    "Jar": "command-runner.jar",
+    "Properties": "",
+    "Name": "jsonl"
+  },
+  {
+    "Args": [
+      "spark-submit",
+      "--deploy-mode",
+      "cluster",
+      "--class",
+      "dpla.batch_process_dpla_index.entries.MqReportsEntry",
+      "s3://dpla-monthly-batch/batch-process-dpla-index-assembly-0.1.jar",
+      "'"$parquet_out"'",
+      "'"$metadata_quality_out"'"
+    ],
+    "Type": "CUSTOM_JAR",
+    "ActionOnFailure": "TERMINATE_CLUSTER",
+    "Jar": "command-runner.jar",
+    "Properties": "",
+    "Name": "mq"
+  },
+  {
+    "Args": [
+      "spark-submit",
+      "--deploy-mode",
+      "cluster",
+      "--class",
+      "dpla.batch_process_dpla_index.entries.SitemapEntry",
+      "s3://dpla-monthly-batch/batch-process-dpla-index-assembly-0.1.jar",
+      "'"$parquet_out"'",
+      "'"$sitemap_out"'",
+      "'"$sitemap_root"'"
+    ],
+    "Type": "CUSTOM_JAR",
+    "ActionOnFailure": "TERMINATE_CLUSTER",
+    "Jar": "command-runner.jar",
+    "Properties": "",
+    "Name": "sitemap"
   }
 ]' \
 --name 'monthlybatch' \

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/MqReportsEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/MqReportsEntry.scala
@@ -9,7 +9,9 @@ import org.apache.spark.sql.SparkSession
   * DPLA Hub Analytics Dashboard.
   *
   * Args
-  *   args(0) = inpath    Local or S3 path to a parquet dump of the DPLA index.
+  *   args(0) = inpath    Local or S3 path to the top-level directory destination of parquet dump of the DPLA index.
+  *                       Month and year will be added to the auto-generated files paths.
+  *                       e.g. s3a://dpla-provider-export/
   *
   *   args(1) = outpath   Local or S3 path to the top-level directory destination.
   *                       Month and year will be added to the auto-generated files paths.

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/SitemapEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/SitemapEntry.scala
@@ -9,7 +9,9 @@ import org.apache.spark.sql.SparkSession
   * Files are compressed for S3 writes (local writes are not compressed).
   *
   * Args
-  *   args(0) = inpath    Local or S3 path to a parquet dump of the DPLA index.
+  *   args(0) = inpath    Local or S3 path to the top-level directory destination of parquet dump of the DPLA index.
+  *                       Month and year will be added to the auto-generated files paths.
+  *                       e.g. s3a://dpla-provider-export/
   *
   *   args(1) = outpath   Local or S3 output path to the top-level directory.
   *                       Date/timestamps will be added to the auto-generated file paths.

--- a/src/main/scala/dpla/batch_process_dpla_index/helpers/PathHelper.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/helpers/PathHelper.scala
@@ -8,5 +8,7 @@ object PathHelper {
   val year: String = dateTime.format(DateTimeFormatter.ofPattern("yyyy"))
   val month: String = dateTime.format(DateTimeFormatter.ofPattern("MM"))
   val timestamp: String = dateTime.format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
-  val outDir: String =  "/" + year + "/" + month
+  val datePath: String =  "/" + year + "/" + month
+
+  val parquetPath: String => String = (base: String) => base.stripSuffix("/") + datePath + "/all.parquet/"
 }

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/MqReports.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/MqReports.scala
@@ -9,9 +9,12 @@ object MqReports extends LocalFileWriter with S3FileHelper with ManifestWriter {
   def execute(spark: SparkSession, inpath: String, outpath: String): String = {
 
     val s3write: Boolean = outpath.startsWith("s3")
-    val outDir: String = outpath.stripSuffix("/") + PathHelper.outDir
+    val outDir: String = outpath.stripSuffix("/") + PathHelper.datePath
+    // delete any existing keys with s3 prefix of outDir
+    if(s3write) deleteS3Path(outDir)
 
-    val docs: DataFrame = spark.read.parquet(inpath)
+    val parquetPath = PathHelper.parquetPath(inpath)
+    val docs: DataFrame = spark.read.parquet(parquetPath)
 
     val items = docs.select("doc.*")
 

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/ParquetDump.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/ParquetDump.scala
@@ -9,7 +9,12 @@ object ParquetDump extends LocalFileWriter with S3FileHelper with ManifestWriter
 
     val s3write: Boolean = outpath.startsWith("s3")
 
-    val outDirBase: String = outpath.stripSuffix("/") + PathHelper.outDir + "/all.parquet/"
+    val outDirBase: String = PathHelper.parquetPath(outpath)
+
+    if (s3write && s3ObjectExists(outDirBase)) {
+      println(s"Deleting existing keys under $outDirBase")
+      deleteS3Path(outDirBase) // parquet out
+    }
 
     // Read data from ElasticSearch and save as parquet
 


### PR DESCRIPTION
- Add delete method to S3FileHelper
- Add parquet path generator to PathHelper
- Delete existing before writing for each executor
- Use generic base path for parquet input
- Separate step invocation in emr