### PR TITLE
Dataprovider as object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ project/plugins/project/
 
 # IntelliJ
 /out/
+.bsp/
 
 # mpeltonen/sbt-idea plugin
 .idea_modules/

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/AllProcessesEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/AllProcessesEntry.scala
@@ -40,7 +40,7 @@ import org.apache.spark.sql.SparkSession
   * A spark-submit invocation requires the following packages:
   *   org.elasticsearch:elasticsearch-spark-20_2.11:7.3.2
   *   com.amazonaws:aws-java-sdk:1.7.4
-  *   org.apache.hadoop:hadoop-aws:2.7.6
+  *   org.apache.hadoop:hadoop-aws:2.7.7
   *   com.squareup.okhttp3:okhttp:3.8.0
   *
   *   Double-check build file for correct package versions

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/JsonlDumpEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/JsonlDumpEntry.scala
@@ -16,7 +16,7 @@ import org.apache.spark.sql.SparkSession
   *
   * A spark-submit invocation requires the following packages:
   *   com.amazonaws:aws-java-sdk:1.7.4
-  *   org.apache.hadoop:hadoop-aws:2.7.6
+  *   org.apache.hadoop:hadoop-aws:2.7.7
   *
   *   Double-check build file for correct package versions
   */

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/MqReportsEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/MqReportsEntry.scala
@@ -19,7 +19,7 @@ import org.apache.spark.sql.SparkSession
   *
   * A spark-submit invocation requires the following packages:
   *   com.amazonaws:aws-java-sdk:1.7.4
-  *   org.apache.hadoop:hadoop-aws:2.7.6
+  *   org.apache.hadoop:hadoop-aws:2.7.7
   *
   *   Double-check build file for correct package versions
   */

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/NecroDataEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/NecroDataEntry.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.SparkSession
   *
   * A spark-submit invocation requires the following packages:
   *   com.amazonaws:aws-java-sdk:1.7.4
-  *   org.apache.hadoop:hadoop-aws:2.7.6
+  *   org.apache.hadoop:hadoop-aws:2.7.7
   *
   *   Double-check build file for correct package versions
   */

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/NecroIndexEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/NecroIndexEntry.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.SparkSession
   * A spark-submit invocation requires the following packages:
   *   org.elasticsearch:elasticsearch-spark-20_2.11:7.3.2
   *   com.amazonaws:aws-java-sdk:1.7.4
-  *   org.apache.hadoop:hadoop-aws:2.7.6
+  *   org.apache.hadoop:hadoop-aws:2.7.7
   *   com.squareup.okhttp3:okhttp:3.8.0
   *
   *   Double-check build file for correct package versions

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/ParquetDumpEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/ParquetDumpEntry.scala
@@ -18,7 +18,7 @@ import org.apache.spark.sql.SparkSession
   * A spark-submit invocation requires the following packages:
   *   org.elasticsearch:elasticsearch-spark-20_2.11:7.3.2
   *   com.amazonaws:aws-java-sdk:1.7.4
-  *   org.apache.hadoop:hadoop-aws:2.7.6
+  *   org.apache.hadoop:hadoop-aws:2.7.7
   *
   *   Double-check build file for correct package versions
   */

--- a/src/main/scala/dpla/batch_process_dpla_index/entries/SitemapEntry.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/entries/SitemapEntry.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.SparkSession
   *
   * A spark-submit invocation requires the following packages:
   *   com.amazonaws:aws-java-sdk:1.7.4
-  *   org.apache.hadoop:hadoop-aws:2.7.6
+  *   org.apache.hadoop:hadoop-aws:2.7.7
   *
   *   Double-check build file for correct package versions
   */

--- a/src/main/scala/dpla/batch_process_dpla_index/helpers/ManifestWriter.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/helpers/ManifestWriter.scala
@@ -1,7 +1,5 @@
 package dpla.batch_process_dpla_index.helpers
 
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
 import scala.collection.immutable.SortedMap
 
 trait ManifestWriter {

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/MqReports.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/MqReports.scala
@@ -22,7 +22,7 @@ object MqReports extends LocalFileWriter with S3FileHelper with ManifestWriter {
 
     val itemdata = spark.sqlContext.sql("""select id,
                                          provider.name as provider,
-                                         dataProvider as dataProviders,
+                                         dataProvider.name as dataProviders,
                                         case
                                           when size(sourceResource.title) == 0
                                           then 0 else 1 end

--- a/src/main/scala/dpla/batch_process_dpla_index/processes/NecroData.scala
+++ b/src/main/scala/dpla/batch_process_dpla_index/processes/NecroData.scala
@@ -32,7 +32,7 @@ object NecroData extends S3FileHelper with LocalFileWriter with ManifestWriter {
       .select(
         col("doc.id"),
         col("doc.provider.name").as("provider"),
-        col("doc.dataProvider"),
+        col("doc.dataProvider.name").as("dataProvider"),
         col("doc.intermediateProvider"),
         col("doc.isShownAt"),
         col("doc.object"),

--- a/src/main/scala/dpla/datasource/DplaDoc.scala
+++ b/src/main/scala/dpla/datasource/DplaDoc.scala
@@ -3,7 +3,7 @@ package dpla.datasource
 case class DplaDoc(
   uri: String, //@id
   id: String,
-  dataProvider: Seq[String],
+  dataProvider: Seq[NamedEntity],
   hasView: Seq[WebResource],
   iiifManifest: Option[String],
   intermediateProvider: Option[String],
@@ -65,7 +65,8 @@ case class Date(
 
 case class NamedEntity(
   uri: Option[String],
-  name: Option[String]
+  name: Option[String],
+  exactMatch: Seq[String]
 )
 
 case class Language(


### PR DESCRIPTION
This allows monthly batch jobs to handle both the old and new data models for `dataProvider`.  
It also adds the `exactMatch` field to both `provider` and `dataProvider`.
And I cleaned up a few small comments and things IntelliJ was complaining about.

The three processes that are affected by the change are:
1. generating the parquet dump
2. generating the MQ (metadata quality) reports
3. generating the necropolis parquet data (which is then indexed in a separate process)

The new data model for `dataProvider` is reflected in the parquet dump, which goes in the public bucket for bulk downloads.  The parquet dump is also used to generate MQ reports, sitemaps, and necropolis data in this application.

The output data structures for the MQ reports and necropolis parquet data are unchanged - they only need to include `dataProvider.name`. So, nothing downstream of these two processes needs to be changed in order consume their output going forward.  In the future, we might want to add `exactMatch` to the necropolis, but that is a decision we can make when we revisit necropolis at a later date.

There were no changes to the processes to generate sitemaps and JSON-L dumps because they do not parse the `dataProvider` field.

I tested this locally by running processes against ElasticSearch indices with both the old and new data models.